### PR TITLE
fix namespace issue

### DIFF
--- a/manifests/ringserver.pp
+++ b/manifests/ringserver.pp
@@ -21,7 +21,7 @@ class swift::ringserver(
   $max_connections = 5
 ) {
 
-  Class['ringbuilder'] -> Class['swift::ringserver']
+  Class['swift::ringbuilder'] -> Class['swift::ringserver']
 
   if !defined(Class['rsync::server']) {
     class { 'rsync::server':


### PR DESCRIPTION
The ringserver manifest is currently referencing an incorrect class. This should be set to call a more fully qualified class name.