### PR TITLE
Handle both string and array for memcache.

### DIFF
--- a/manifests/proxy/cache.pp
+++ b/manifests/proxy/cache.pp
@@ -23,7 +23,7 @@ class swift::proxy::cache(
 ) {
 
   # require the memcached class if its on the same machine
-  if $memcache_servers =~ /^127\.0\.0\.1/ {
+  if ((is_array($memcache_servers) and grep($memcache_servers, /^127\.0\.0\.1/)) or (is_string($memcache_servers) and $memcache_servers =~ /^127\.0\.0\.1/)) {
     Class['memcached'] -> Class['swift::proxy::cache']
   }
 


### PR DESCRIPTION
The cache class has an array for a parameter, but tests like it's a string, which fails.

Signed-off-by: Robin H. Johnson <robbat2@gentoo.org>