### PR TITLE
fix testing memcache_servers for localhost under Puppet 4

### DIFF
--- a/manifests/proxy/cache.pp
+++ b/manifests/proxy/cache.pp
@@ -23,7 +23,7 @@ class swift::proxy::cache(
 ) {
 
   # require the memcached class if its on the same machine
-  if $memcache_servers =~ /^127\.0\.0\.1/ {
+  if (grep(any2array($memcache_servers), '^127.0.0.1')) {
     Class['memcached'] -> Class['swift::proxy::cache']
   }
 


### PR DESCRIPTION
When running under Puppet 4 (or presumably simply with the future parser), an
error is raised when trying to perform a regex check against an array. Using
functions from the stdlib module, ensure $memcache_servers is an array before
using `grep` to check each element for localhost.